### PR TITLE
Handle DAR flow exit command

### DIFF
--- a/index.js
+++ b/index.js
@@ -438,6 +438,13 @@ async function startBot() {
     const corpoMensagem = msg.message.conversation || msg.message.extendedTextMessage?.text || "";
     const pergunta = corpoMensagem.trim(); // mantém case quando necessário
 
+    if ((usuarios[jid]?.opcoesDar || usuarios[jid]?.aguardandoConfirmacaoDar) && /^sair$/i.test(pergunta)) {
+      delete usuarios[jid].opcoesDar;
+      delete usuarios[jid].aguardandoConfirmacaoDar;
+      await sock.sendMessage(jid, { text: 'Fluxo de DAR encerrado. Se precisar de algo mais, é só me chamar! 👋' });
+      return;
+    }
+
     // ✅ NOVA LÓGICA: DARs por WhatsApp (antes de qualquer early-return)
     const textoLow = (corpoMensagem || '').toLowerCase();
     if (!(isGroup && !textoLow.includes('@bot'))) {


### PR DESCRIPTION
## Summary
- detect `SAIR` command during DAR interactions
- clear DAR state and inform user when exiting

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4da4d77ec833394c27d66f214460c