### PR TITLE
Orientar atualização de telefone pelo portal

### DIFF
--- a/index.js
+++ b/index.js
@@ -507,7 +507,7 @@ async function startBot() {
           if (/associado a nenhum/i.test(msg)) {
             await sock.sendMessage(jid, { text:
               "Não localizei seu cadastro pelo número deste WhatsApp.\n" +
-              "Fale com a administração para atualizar seu telefone (principal ou de cobrança)."
+              "Atualize seu telefone no portal do permissionário/cliente."
             });
           } else {
             await sock.sendMessage(jid, { text: `Tive um problema ao consultar suas DARs: ${msg}` });


### PR DESCRIPTION
## Summary
- Ajusta mensagem de cadastro para orientar atualização de telefone pelo portal do permissionário/cliente

## Testing
- `npm test` *(erro: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4e49b3ad883338fb1b2250c0e8aa9