### PR TITLE
Valida seleção de DAR e trata opção inválida

### DIFF
--- a/index.js
+++ b/index.js
@@ -483,7 +483,7 @@ async function startBot() {
     if (!(isGroup && !textoLow.includes('@bot'))) {
       const numeroEscolhido = pergunta.trim();
       if (/^\d+$/.test(numeroEscolhido) && usuarios[jid]?.darMap) {
-        const darId = usuarios[jid].darMap[numeroEscolhido];
+        const darId = usuarios[jid].darMap[numeroEscolhido]?.id;
         if (darId) {
           const msisdnBase = usuarios[jid]?.msisdnCorrigido || msisdnFromJid(jid);
           try {
@@ -493,9 +493,11 @@ async function startBot() {
           } catch (e) {
             await sock.sendMessage(jid, { text: `Não consegui recuperar a DAR selecionada: ${e.message}` });
           }
-
-          return;
+        } else {
+          await sock.sendMessage(jid, { text: 'Opção inválida. Digite um número da lista ou "SAIR" para encerrar.' });
         }
+
+        return;
       }
 
       const pedeDAR = /\b(dar|boleto|2.?via|segunda via)\b/i.test(textoLow);


### PR DESCRIPTION
## Summary
- Corrige leitura da DAR selecionada usando o identificador do mapa
- Responde ao usuário quando a opção informada é inválida

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4e91ecb5c8333808e6c736c9fbf8e