### PR TITLE
Handle DAR number replies with punctuation

### DIFF
--- a/index.js
+++ b/index.js
@@ -513,11 +513,11 @@ async function startBot() {
     // ✅ NOVA LÓGICA: DARs por WhatsApp (antes de qualquer early-return)
     const textoLow = (corpoMensagem || '').toLowerCase();
     if (!(isGroup && !textoLow.includes('@bot'))) {
-      const numeroEscolhido = pergunta.trim();
-      if (/^\d+$/.test(numeroEscolhido) && usuarios[jid]?.darMap) {
+      const numeroEscolhido = pergunta.match(/\d+/)?.[0];
+      if (numeroEscolhido && usuarios[jid]?.darMap) {
         const darEntry = usuarios[jid].darMap[numeroEscolhido];
-        if (darEntry) {
-          const darId = typeof darEntry === 'object' ? darEntry.id : darEntry;
+        if (darEntry?.id) {
+          const darId = darEntry.id;
           const msisdnBase = usuarios[jid]?.msisdnCorrigido || msisdnFromJid(jid);
           try {
             const { linha_digitavel, pdf_url, msisdnCorrigido } = await apiEmitDar(darId, msisdnBase);
@@ -537,9 +537,10 @@ async function startBot() {
             await sock.sendMessage(jid, { text: `Não consegui recuperar a DAR selecionada: ${e.message}` });
           }
         } else {
-          await sock.sendMessage(jid, { text: 'Opção inválida. Digite um número da lista ou "SAIR" para encerrar.' });
+          await sock.sendMessage(jid, { text: 'DAR não disponível' });
         }
-      } else if (/^mais$/i.test(numeroEscolhido) && usuarios[jid]?.darPayload) {
+        return;
+      } else if (/^mais$/i.test(pergunta) && usuarios[jid]?.darPayload) {
         const state = usuarios[jid].darOffsets || { vig: 0, venc: 0 };
         const msisdnBase = usuarios[jid]?.msisdnCorrigido || msisdnFromJid(jid);
         const { texto, mapa, mostradas } = await montarTextoResposta(msisdnBase, usuarios[jid].darPayload, {


### PR DESCRIPTION
## Summary
- Extract first number in user reply to handle inputs like "1)" or "nº 1"
- Validate DAR entries before emission and warn when unavailable

## Testing
- `node --check index.js`
- `node -e 'const usuarios={jid:{darMap:{1:{id:1}}}}; const arr=["1)", "1 -", "nº 1", "nº\u202f1"]; arr.forEach(p=>{ const n=p.match(/\d+/)?.[0]; const trig=!!(n && usuarios.jid?.darMap); console.log(p, "->", n, "trigger?", trig); });'`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5f760b1d8833385e7cb4c7bb9706f