### PR TITLE
Handle base64 DAR PDFs

### DIFF
--- a/index.js
+++ b/index.js
@@ -547,10 +547,26 @@ async function startBot() {
           try {
             const { linha_digitavel, pdf_url, msisdnCorrigido } = await apiEmitDar(darId, msisdnBase);
             usuarios[jid].msisdnCorrigido = msisdnCorrigido;
-            const pdfUrl = pdf_url || pdfLink(darId, msisdnCorrigido);
+            let pdfUrl = null;
+            let pdfBuffer = null;
+            if (pdf_url) {
+              if (/^https?:\/\//i.test(pdf_url)) {
+                pdfUrl = pdf_url;
+              } else {
+                pdfBuffer = Buffer.from(pdf_url, 'base64');
+              }
+            } else {
+              pdfUrl = pdfLink(darId, msisdnCorrigido);
+            }
             if (pdfUrl) {
               await sock.sendMessage(jid, {
                 document: { url: pdfUrl },
+                mimetype: 'application/pdf',
+                fileName: `DAR-${darId}.pdf`
+              });
+            } else if (pdfBuffer) {
+              await sock.sendMessage(jid, {
+                document: pdfBuffer,
                 mimetype: 'application/pdf',
                 fileName: `DAR-${darId}.pdf`
               });
@@ -691,10 +707,26 @@ async function startBot() {
           try {
             const { linha_digitavel, pdf_url, msisdnCorrigido } = await apiEmitDar(darId, msisdnBase);
             usuarios[jid].msisdnCorrigido = msisdnCorrigido;
-            const pdfUrl = pdf_url || pdfLink(darId, msisdnCorrigido);
+            let pdfUrl = null;
+            let pdfBuffer = null;
+            if (pdf_url) {
+              if (/^https?:\/\//i.test(pdf_url)) {
+                pdfUrl = pdf_url;
+              } else {
+                pdfBuffer = Buffer.from(pdf_url, 'base64');
+              }
+            } else {
+              pdfUrl = pdfLink(darId, msisdnCorrigido);
+            }
             if (pdfUrl) {
               await sock.sendMessage(jid, {
                 document: { url: pdfUrl },
+                mimetype: 'application/pdf',
+                fileName: `DAR-${darId}.pdf`
+              });
+            } else if (pdfBuffer) {
+              await sock.sendMessage(jid, {
+                document: pdfBuffer,
                 mimetype: 'application/pdf',
                 fileName: `DAR-${darId}.pdf`
               });


### PR DESCRIPTION
## Summary
- handle DAR responses that return base64 PDFs
- support either URL or base64 when sending DAR documents

## Testing
- `node tests/pedeDAR.test.js`
- `node - <<'NODE'
const pdf_url = Buffer.from('Dummy PDF data', 'utf8').toString('base64');
const darId = 123;
let pdfUrl = null;
let pdfBuffer = null;
if (pdf_url) {
  if (/^https?:\/\//i.test(pdf_url)) {
    pdfUrl = pdf_url;
  } else {
    pdfBuffer = Buffer.from(pdf_url, 'base64');
  }
}
const sock = { sendMessage: async (jid, msg) => { console.log('sendMessage called with Buffer?', Buffer.isBuffer(msg.document), 'size', msg.document.length); }};
if (pdfUrl) {
  sock.sendMessage('test', { document: { url: pdfUrl }, mimetype: 'application/pdf', fileName: `DAR-${darId}.pdf` });
} else if (pdfBuffer) {
  sock.sendMessage('test', { document: pdfBuffer, mimetype: 'application/pdf', fileName: `DAR-${darId}.pdf` });
}
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a5feee10348333946f4f75a284276e