### PR TITLE
Normalize DAR fields from alternate API responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,28 @@ async function apiEmitDar(darId, msisdn, retry = 0){
   });
   const data = await r.json().catch(() => ({}));
   const dar = data?.dar || data?.data?.dar || data?.data || data;
-  const { linha_digitavel, pdf_url, competencia, vencimento, valor } = dar || {};
+  let {
+    linha_digitavel,
+    pdf_url,
+    competencia,
+    vencimento,
+    valor,
+    mes_referencia,
+    ano_referencia,
+    data_vencimento
+  } = dar || {};
+
+  if (!competencia && mes_referencia != null && ano_referencia != null) {
+    competencia = `${String(mes_referencia).padStart(2, '0')}/${ano_referencia}`;
+  }
+
+  if (!vencimento && data_vencimento) {
+    vencimento = data_vencimento;
+  }
+
+  if (valor == null) {
+    valor = dar?.valor_total ?? dar?.total;
+  }
 
   const ensureFields = () => {
     if (!linha_digitavel || !competencia || !vencimento || valor == null) {
@@ -830,6 +851,10 @@ async function main() {
   });
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { apiEmitDar };
 
 // (sem lógica de desligamento gracioso)

--- a/tests/apiEmitDar.test.js
+++ b/tests/apiEmitDar.test.js
@@ -1,0 +1,86 @@
+const assert = require('assert');
+const path = require('path');
+const Module = require('module');
+
+function loadApiEmitDar(response) {
+  const fetchMock = async () => ({ ok: true, json: async () => response });
+  const indexPath = path.resolve(__dirname, '..', 'index.js');
+  const originalRequire = Module.prototype.require;
+
+  Module.prototype.require = function (moduleName) {
+    if (moduleName === 'node-fetch') return fetchMock;
+    if (moduleName === 'express') {
+      const fn = () => ({ get(){}, listen(){}, use(){} });
+      fn.json = () => (req, res, next) => next();
+      return fn;
+    }
+    if (moduleName === 'dotenv') return { config(){} };
+    if (moduleName === 'pdf-parse') return async () => {};
+    if (moduleName === 'langchain/text_splitter') return { RecursiveCharacterTextSplitter: class {} };
+    if (moduleName === '@whiskeysockets/baileys') return {
+      makeWASocket: () => ({}),
+      useMultiFileAuthState: async () => ({ state: {}, saveCreds: async () => {} }),
+      DisconnectReason: {}
+    };
+    if (moduleName === 'openai') return class {};
+    if (moduleName === 'node-cron') return { schedule(){} };
+    if (moduleName === 'sqlite3') return { verbose: () => ({ Database: function(){} }) };
+    if (moduleName === './ciptPrompt.js') return { getCiptPrompt: async () => '' };
+    if (moduleName === './sheetsChamados') return {
+      registrarChamado: async () => {},
+      atualizarStatusChamado: async () => {},
+      verificarChamadosAbertos: async () => []
+    };
+    return originalRequire.apply(this, arguments);
+  };
+
+  delete require.cache[indexPath];
+  const { apiEmitDar } = require(indexPath);
+  Module.prototype.require = originalRequire;
+  delete require.cache[indexPath];
+  return apiEmitDar;
+}
+
+(async () => {
+  let apiEmitDar = loadApiEmitDar({
+    dar: {
+      linha_digitavel: '123',
+      pdf_url: 'http://exemplo',
+      competencia: '07/2024',
+      vencimento: '2024-07-10',
+      valor: 50
+    }
+  });
+  let res = await apiEmitDar('1', '5511999999999');
+  assert.deepStrictEqual(res, {
+    linha_digitavel: '123',
+    pdf_url: 'http://exemplo',
+    competencia: '07/2024',
+    vencimento: '2024-07-10',
+    valor: 50,
+    msisdnCorrigido: '5511999999999'
+  });
+
+  apiEmitDar = loadApiEmitDar({
+    dar: {
+      linha_digitavel: '456',
+      pdf_url: 'http://alt',
+      mes_referencia: 7,
+      ano_referencia: 2024,
+      data_vencimento: '2024-07-10',
+      valor_total: 75
+    }
+  });
+  res = await apiEmitDar('2', '5511999999999');
+  assert.deepStrictEqual(res, {
+    linha_digitavel: '456',
+    pdf_url: 'http://alt',
+    competencia: '07/2024',
+    vencimento: '2024-07-10',
+    valor: 75,
+    msisdnCorrigido: '5511999999999'
+  });
+
+  console.log('All apiEmitDar tests passed');
+})();
+


### PR DESCRIPTION
## Summary
- derive `competencia` and `vencimento` from `mes_referencia`/`ano_referencia` and `data_vencimento` when missing
- validate using computed values and return normalized DAR fields
- add unit tests covering alternate DAR field names

## Testing
- `node tests/apiEmitDar.test.js`
- `node tests/pedeDAR.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a61b275e8c8333a14c4b40bda2a3d4