### PR TITLE
Log details for fallback GET failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -248,6 +248,13 @@ async function apiEmitDar(darId, msisdn, retry = 0) {
         const resGet = await api.get(`/api/bot/dars/${darId}`);
         return ensureFields(extract(resGet.data));
       } catch (consultaErr) {
+        const status = consultaErr.response?.status;
+        const data = consultaErr.response?.data;
+        if (consultaErr.response) {
+          console.error('Fallback GET falhou:', status, data);
+        } else {
+          console.error('Fallback GET falhou:', consultaErr.message);
+        }
         if (/Campos ausentes/i.test(consultaErr.message)) {
           throw new Error('sem dados retornados');
         }


### PR DESCRIPTION
## Summary
- Capture status and data when fallback GET request fails after a 409
- Log fallback GET error details or message when no response is present before throwing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a637058d248333b2022bc63adf7d11