### PR TITLE
feat: query DAR using numero_documento

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,24 +236,20 @@ async function apiEmitDar(darId, msisdn, retry = 0) {
     const data = errBody.response?.data;
     const msg = data?.error || errBody.message || 'Falha ao emitir DAR';
 
-    // 409 -> já emitida: consulta com msisdn e, se vier incompleto, sem msisdn
+    // 409 -> já emitida: consulta usando numero_documento
     if (status === 409 || /dar j[aá] emitid/i.test(msg)) {
       try {
-        const resGet = await api.get(`/api/bot/dars/${darId}?msisdn=${msisdn}`);
-        return ensureFields(extract(resGet.data));
-      } catch (primeiraConsultaErr) {
-        // tenta novamente sem msisdn, ignorando erro da primeira tentativa
-      }
-      try {
-        const resGet = await api.get(`/api/bot/dars/${darId}`);
+        const resGet = await api.get('/api/bot/dars', {
+          params: { numero_documento: darId },
+        });
         return ensureFields(extract(resGet.data));
       } catch (consultaErr) {
         const status = consultaErr.response?.status;
         const data = consultaErr.response?.data;
         if (consultaErr.response) {
-          console.error('Fallback GET falhou:', status, data);
+          console.error('Consulta GET falhou:', status, data);
         } else {
-          console.error('Fallback GET falhou:', consultaErr.message);
+          console.error('Consulta GET falhou:', consultaErr.message);
         }
         if (/Campos ausentes/i.test(consultaErr.message)) {
           throw new Error('sem dados retornados');

--- a/tests/apiEmitDar.test.js
+++ b/tests/apiEmitDar.test.js
@@ -151,6 +151,8 @@ function loadApiEmitDar(responses) {
     msisdnCorrigido: '5511999999999'
   });
   assert.strictEqual(apiEmitDar.axiosCalls.length, 2);
+  assert.strictEqual(apiEmitDar.axiosCalls[1].url, '/api/bot/dars');
+  assert.strictEqual(apiEmitDar.axiosCalls[1].config.params.numero_documento, '4');
 
   apiEmitDar = loadApiEmitDar([
     { ok: false, body: { error: 'DAR já emitida' } },
@@ -202,32 +204,18 @@ function loadApiEmitDar(responses) {
     msisdnCorrigido: '5511999999999'
   });
 
-  // Fallback GET primeiro com msisdn e depois sem msisdn
+  // Erro 400 ao consultar DAR já emitida com numero_documento inválido
   apiEmitDar = loadApiEmitDar([
     { ok: false, body: { error: 'DAR já emitida' } },
-    { ok: false, body: { error: 'msisdn inválido' } },
-    { ok: true, body: { dados: { dar: {
-      linhaDigitavel: '1212',
-      pdfUrl: 'http://semmsisdn',
-      mesReferencia: 11,
-      anoReferencia: 2024,
-      dataVencimento: '2024-11-11',
-      valorTotal: 300
-    } } } }
+    { status: 400, body: { error: 'numero_documento inválido' } }
   ]);
-  res = await apiEmitDar('8', '5511999999999');
-  assert.deepStrictEqual(res, {
-    linha_digitavel: '1212',
-    pdf_url: 'http://semmsisdn',
-    competencia: '11/2024',
-    vencimento: '2024-11-11',
-    valor: 300,
-    msisdnCorrigido: '5511999999999'
-  });
-  assert.strictEqual(apiEmitDar.axiosCalls.length, 3);
-  assert(apiEmitDar.axiosCalls[0].url.includes('?msisdn=5511999999999'));
-  assert(apiEmitDar.axiosCalls[1].url.includes('?msisdn=5511999999999'));
-  assert(!apiEmitDar.axiosCalls[2].url.includes('msisdn'));
+  await assert.rejects(
+    () => apiEmitDar('8', '5511999999999'),
+    /numero_documento inválido/
+  );
+  assert.strictEqual(apiEmitDar.axiosCalls.length, 2);
+  assert.strictEqual(apiEmitDar.axiosCalls[1].url, '/api/bot/dars');
+  assert.strictEqual(apiEmitDar.axiosCalls[1].config.params.numero_documento, '8');
 
   console.log('All apiEmitDar tests passed');
 })();


### PR DESCRIPTION
## Summary
- use `numero_documento` to consult DAR after a 409 response during emission
- update `apiEmitDar` tests for new consulta route and 400 error handling

## Testing
- `node tests/apiEmitDar.test.js`
- `node tests/pedeDAR.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a63abcc2f083338a646bdb07f150c5