### PR TITLE
Include msisdn on DAR lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -240,7 +240,7 @@ async function apiEmitDar(darId, msisdn, retry = 0) {
     if (status === 409 || /dar j[aá] emitid/i.test(msg)) {
       try {
         const resGet = await api.get('/api/bot/dars', {
-          params: { numero_documento: darId },
+          params: { numero_documento: darId, msisdn },
         });
         return ensureFields(extract(resGet.data));
       } catch (consultaErr) {

--- a/tests/apiEmitDar.test.js
+++ b/tests/apiEmitDar.test.js
@@ -153,6 +153,7 @@ function loadApiEmitDar(responses) {
   assert.strictEqual(apiEmitDar.axiosCalls.length, 2);
   assert.strictEqual(apiEmitDar.axiosCalls[1].url, '/api/bot/dars');
   assert.strictEqual(apiEmitDar.axiosCalls[1].config.params.numero_documento, '4');
+  assert.strictEqual(apiEmitDar.axiosCalls[1].config.params.msisdn, '5511999999999');
 
   apiEmitDar = loadApiEmitDar([
     { ok: false, body: { error: 'DAR já emitida' } },
@@ -216,6 +217,7 @@ function loadApiEmitDar(responses) {
   assert.strictEqual(apiEmitDar.axiosCalls.length, 2);
   assert.strictEqual(apiEmitDar.axiosCalls[1].url, '/api/bot/dars');
   assert.strictEqual(apiEmitDar.axiosCalls[1].config.params.numero_documento, '8');
+  assert.strictEqual(apiEmitDar.axiosCalls[1].config.params.msisdn, '5511999999999');
 
   console.log('All apiEmitDar tests passed');
 })();


### PR DESCRIPTION
## Summary
- Include `msisdn` query parameter when retrieving a previously emitted DAR
- Assert `msisdn` is sent in API GET requests in `apiEmitDar` tests

## Testing
- `node tests/apiEmitDar.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a64033dfcc8333b38cfde3d9b6b9ee