### PR TITLE
Use dedicated DAR endpoint and improve error logging

### DIFF
--- a/tests/apiEmitDar.test.js
+++ b/tests/apiEmitDar.test.js
@@ -151,8 +151,7 @@ function loadApiEmitDar(responses) {
     msisdnCorrigido: '5511999999999'
   });
   assert.strictEqual(apiEmitDar.axiosCalls.length, 2);
-  assert.strictEqual(apiEmitDar.axiosCalls[1].url, '/api/bot/dars');
-  assert.strictEqual(apiEmitDar.axiosCalls[1].config.params.numero_documento, '4');
+  assert.strictEqual(apiEmitDar.axiosCalls[1].url, '/api/bot/dars/4');
   assert.strictEqual(apiEmitDar.axiosCalls[1].config.params.msisdn, '5511999999999');
 
   apiEmitDar = loadApiEmitDar([
@@ -215,8 +214,7 @@ function loadApiEmitDar(responses) {
     /numero_documento inválido/
   );
   assert.strictEqual(apiEmitDar.axiosCalls.length, 2);
-  assert.strictEqual(apiEmitDar.axiosCalls[1].url, '/api/bot/dars');
-  assert.strictEqual(apiEmitDar.axiosCalls[1].config.params.numero_documento, '8');
+  assert.strictEqual(apiEmitDar.axiosCalls[1].url, '/api/bot/dars/8');
   assert.strictEqual(apiEmitDar.axiosCalls[1].config.params.msisdn, '5511999999999');
 
   console.log('All apiEmitDar tests passed');


### PR DESCRIPTION
## Summary
- Fetch existing DARs using `/api/bot/dars/:darId` when emission returns 409
- Log status and body when the API response lacks DAR data
- Update tests for new endpoint and error handling behavior

## Testing
- `node tests/apiEmitDar.test.js`
- `node tests/pedeDAR.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a645400fdc8333a4d3480dc9430306