### PR TITLE
Expose missing field names in DAR fallback GET error

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,7 +247,12 @@ async function apiEmitDar(darId, msisdn, retry = 0) {
         } catch (e) {
           console.error('Consulta GET falhou:', resGet.status, resGet.data);
           if (/Campos ausentes/i.test(e.message)) {
-            throw new Error('sem dados retornados');
+            const missing = e.message
+              .split(':')[1]
+              ?.split(',')
+              .map((s) => s.trim())
+              .filter(Boolean) || [];
+            throw new Error(`Campos ausentes: ${missing.join(', ')}`);
           }
           const sMsg = sanitizeSensitive(e.message);
           throw new Error(sMsg);

--- a/tests/apiEmitDar.test.js
+++ b/tests/apiEmitDar.test.js
@@ -163,7 +163,7 @@ function loadApiEmitDar(responses) {
   ]);
   await assert.rejects(
     () => apiEmitDar('5', '5511999999999'),
-    /sem dados retornados/
+    /Campos ausentes: linha_digitavel, competencia, vencimento, valor/
   );
 
   apiEmitDar = loadApiEmitDar({


### PR DESCRIPTION
## Summary
- surface missing field names when fallback GET lacks DAR data
- update tests to assert detailed missing-field error

## Testing
- `node tests/apiEmitDar.test.js`
- `node tests/pedeDAR.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6481afeec83339a3e4f4243ad51fb