### PR TITLE
docs: document POST send endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Exemplo de configuração de variáveis de ambiente para o bot
+
+# Token usado para autenticar chamadas ao endpoint POST /send
+WHATSAPP_BOT_TOKEN=seu_token_aqui
+
+# Habilita logs detalhados de autenticação (opcional)
+BOT_AUTH_DEBUG=false
+
+# Caminho local do banco SQLite
+DB_PATH=./sistemacipt.db
+
+# URL de um banco de dados remoto (caso não utilize o arquivo local)
+#REMOTE_DB_URL=
+
+# Credenciais do sistema de pagamento
+BOT_SHARED_KEY=sua_chave_secreta
+ADMIN_API_BASE=https://pagamentos.exemplo.com/api/admin
+ADMIN_PUBLIC_BASE=https://pagamentos.exemplo.com

--- a/README.md
+++ b/README.md
@@ -41,6 +41,43 @@ export ADMIN_PUBLIC_BASE="https://pagamentos.exemplo.com"
 
 Certifique-se de manter a chave compartilhada em local seguro e não versioná-la.
 
+## Envio de mensagens via API
+
+O bot expõe um endpoint HTTP que permite o envio de mensagens de texto para um número do WhatsApp.
+
+### `POST /send`
+
+Envia uma mensagem para o número especificado.
+
+**Cabeçalhos**
+
+- `Authorization: Bearer <WHATSAPP_BOT_TOKEN>`
+- `Content-Type: application/json`
+
+**Exemplo de requisição**
+
+```bash
+curl -X POST http://localhost:3000/send \
+  -H "Authorization: Bearer supersecreto" \
+  -H "Content-Type: application/json" \
+  -d '{"to":"5582999999999","message":"Olá!"}'
+```
+
+**Resposta**
+
+```json
+{ "success": true }
+```
+
+### Variáveis de ambiente
+
+```
+WHATSAPP_BOT_TOKEN=supersecreto
+#BOT_AUTH_DEBUG=true
+```
+
+`WHATSAPP_BOT_TOKEN` define o token aceito pelo middleware de autenticação. Defina `BOT_AUTH_DEBUG` como `true` para habilitar logs de depuração.
+
 ## Executando
 
 ```bash


### PR DESCRIPTION
## Summary
- document POST /send endpoint with Authorization header in README
- add .env.example including WHATSAPP_BOT_TOKEN and BOT_AUTH_DEBUG

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c07eb3d83c8333b211da50577e2fb0