### PR TITLE
Improve error handling for sending messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -992,14 +992,20 @@ async function main() {
           await sock.presenceSubscribe(jid).catch(() => {});
           await sock.sendPresenceUpdate('composing', jid).catch(() => {});
 
-          // Se preferir timeout no envio, troque a linha abaixo por:
-          // await withTimeout(sock.sendMessage(jid, { text }), 8000);
-          await sock.sendMessage(jid, { text });
+          try {
+            // Se preferir timeout no envio, troque a linha abaixo por:
+            // await withTimeout(sock.sendMessage(jid, { text }), 8000);
+            await sock.sendMessage(jid, { text });
 
-          await sock.sendPresenceUpdate('available', jid).catch(() => {});
-          console.log(sanitizeSensitive(`[send][ok] -> ${jid} (${String(text).length} chars)`));
+            console.log(sanitizeSensitive(`[send][ok] -> ${jid} (${String(text).length} chars)`));
+          } catch (err) {
+            console.error('[send][bg][erro]:', err?.stack || err, err?.data || err?.output);
+            if (!res.headersSent) res.status(500).json({ ok: false, erro: 'internal' });
+          } finally {
+            await sock.sendPresenceUpdate('available', jid).catch(() => {});
+          }
         } catch (err) {
-          console.error('[send][bg][erro]:', err?.stack || err);
+          console.error('[send][bg][erro]:', err?.stack || err, err?.data || err?.output);
         }
       });
     } catch (e) {


### PR DESCRIPTION
## Summary
- wrap sendMessage in a nested try/catch with detailed logging
- respond with 500 if message send fails before headers are sent

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c19ba0ce248333a78fe1ffb004988e