### PR TITLE
Add websocket disconnect test for send handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Assistente Virtual do CIPT para WhatsApp",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "node tests/sendMessage.test.js && node tests/apiEmitDar.test.js && node tests/pedeDAR.test.js"
   },
   "author": "Pedro Ivo Souza",
   "license": "ISC",

--- a/tests/sendMessage.test.js
+++ b/tests/sendMessage.test.js
@@ -94,6 +94,13 @@ async function loadSendMessage() {
   let res = await invoke({}, { msisdn: '123', text: 'oi' });
   assert.strictEqual(res.statusCode, 401, 'requires auth header');
 
+  // WhatsApp socket not connected
+  sockMock.ws.readyState = 0;
+  res = await invoke({ authorization: 'Bearer secret' }, { msisdn: '5511999999999', text: 'Oi' });
+  assert.strictEqual(res.statusCode, 503);
+  assert.deepStrictEqual(res.jsonBody, { ok: false, erro: 'whatsapp não conectado' });
+  sockMock.ws.readyState = 1;
+
   // Número não encontrado no WhatsApp
   sockMock.onWhatsApp = async () => [];
   res = await invoke({ authorization: 'Bearer secret' }, { msisdn: '5511999999999', text: 'Oi' });


### PR DESCRIPTION
## Summary
- verify `/send` returns 503 when the WhatsApp socket isn't connected
- expose npm test script to run all test files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c19f1564f08333b5a8ebef9a9d5f13