### PR TITLE
refactor: remove background error response from /send

### DIFF
--- a/index.js
+++ b/index.js
@@ -1000,7 +1000,6 @@ async function main() {
             console.log(sanitizeSensitive(`[send][ok] -> ${jid} (${String(text).length} chars)`));
           } catch (err) {
             console.error('[send][bg][erro]:', err?.stack || err, err?.data || err?.output);
-            if (!res.headersSent) res.status(500).json({ ok: false, erro: 'internal' });
           } finally {
             await sock.sendPresenceUpdate('available', jid).catch(() => {});
           }


### PR DESCRIPTION
## Summary
- avoid sending an HTTP 500 from the `/send` background task by removing extra `res.status` call
- keep console error logging so send failures remain recorded

## Testing
- `node tests/apiEmitDar.test.js`
- `node tests/pedeDAR.test.js`
- `node tests/sendMessage.test.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c19f11545483338b245cf1d8378663