### PR TITLE
Add connection status to root route

### DIFF
--- a/index.js
+++ b/index.js
@@ -939,7 +939,16 @@ async function main() {
   const SEND_TOKEN = process.env.WHATSAPP_BOT_TOKEN || process.env.BOT_SHARED_KEY;
 
   // healthcheck
-  app.get('/', (req, res) => res.send('✅ Bot do CIPT está online!'));
+  app.get('/', (req, res) => {
+    const isConnected = sock?.ws?.readyState === 1; // 1 = OPEN
+    if (req.accepts('json')) {
+      return res.json({ ok: true, connected: isConnected });
+    }
+    const html = isConnected
+      ? '<p>✅ Bot do CIPT está online!</p>'
+      : '<p>⏳ Bot ainda está inicializando...</p>';
+    res.send(html);
+  });
 
   // envio de mensagens
   app.post('/send', async (req, res) => {


### PR DESCRIPTION
## Summary
- expose WhatsApp connection state on GET /
- show HTML status message only when bot is connected

## Testing
- `npm test` *(fails: Invalid package.json: Expected ',' or '}' after property value in JSON at position 295)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a1f6d67883339af26bad9ff23360