### PR TITLE
use global connection flag in root route

### DIFF
--- a/index.js
+++ b/index.js
@@ -942,7 +942,6 @@ async function main() {
 
   // healthcheck
   app.get('/', (req, res) => {
-    const isConnected = sock?.ws?.readyState === 1; // 1 = OPEN
     if (req.accepts('json')) {
       return res.json({ ok: true, connected: isConnected });
     }


### PR DESCRIPTION
## Summary
- use global `isConnected` flag for healthcheck instead of websocket readyState

## Testing
- `npm test` *(fails: Invalid package.json JSONParseError)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a37906808333ab84d55ae3b66d36