### PR TITLE
Ensure socket cleanup before reconnecting

### DIFF
--- a/index.js
+++ b/index.js
@@ -635,6 +635,10 @@ async function enviarRelatorioDePendencias(sockInstancia) {
 async function startBot() {
   const { state, saveCreds } = await useMultiFileAuthState(authPath);
   // sempre resetar o status de conexão ao (re)criar o socket
+  if (sock) {
+    try { sock.ws?.close(); } catch {}
+    try { sock.ev?.removeAllListeners?.(); } catch {}
+  }
   isConnected = false;
   sock = makeWASocket({ auth: state });
   global.sock = sock;


### PR DESCRIPTION
## Summary
- Gracefully close and detach existing WhatsApp socket before creating a new one
- Extend reconnect test to assert only one active socket and proper cleanup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1d73c6ff0833394c87e25a917492c