### PR TITLE
Add startup lockfile to prevent multiple instances

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,13 +2,32 @@
 // CIPT-WHATSAPP-BOT - VERSÃO DE PRODUÇÃO FINAL (COM D.A.R. via WhatsApp)
 // =================================================================================================
 
+const fs = require('fs');
+const path = require('path');
+
+const LOCK_FILE = path.join(__dirname, 'cipt-bot.lock');
+try {
+  fs.closeSync(fs.openSync(LOCK_FILE, 'wx'));
+} catch (err) {
+  if (err.code === 'EEXIST') {
+    console.error(`Lockfile ${LOCK_FILE} already exists. Another instance may be running.`);
+    process.exit(1);
+  }
+  throw err;
+}
+
+function removeLock() {
+  try { fs.unlinkSync(LOCK_FILE); } catch {}
+}
+process.on('exit', removeLock);
+process.once('SIGINT', () => { removeLock(); process.exit(0); });
+process.once('SIGTERM', () => { removeLock(); process.exit(0); });
+
 const crypto = require("node:crypto");
 global.crypto = crypto;
 
 const express = require('express');
 const dotenv = require('dotenv');
-const fs = require('fs');
-const path = require('path');
 const pdfParse = require('pdf-parse');
 const { RecursiveCharacterTextSplitter } = require("langchain/text_splitter");
 const { makeWASocket, useMultiFileAuthState, DisconnectReason } = require('@whiskeysockets/baileys');

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "node tests/sendMessage.test.js && node tests/apiEmitDar.test.js && node tests/pedeDAR.test.js && node tests/reconnect.test.js"
+    "test": "node tests/lockfile.test.js && node tests/sendMessage.test.js && node tests/apiEmitDar.test.js && node tests/pedeDAR.test.js && node tests/reconnect.test.js"
   },
   "author": "Pedro Ivo Souza",
   "license": "ISC",

--- a/tests/lockfile.test.js
+++ b/tests/lockfile.test.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const Module = require('module');
+
+const LOCK_PATH = path.resolve(__dirname, '..', 'cipt-bot.lock');
+
+function loadIndex() {
+  const indexPath = path.resolve(__dirname, '..', 'index.js');
+  const originalRequire = Module.prototype.require;
+  Module.prototype.require = function (moduleName) {
+    if (moduleName === 'axios') return { interceptors: { request: { use(){} } }, create(){ return this; } };
+    if (moduleName === 'express') {
+      const fn = () => ({ get(){}, listen(){}, use(){} });
+      fn.json = () => (req, res, next) => next();
+      return fn;
+    }
+    if (moduleName === 'dotenv') return { config(){} };
+    if (moduleName === 'pdf-parse') return async () => {};
+    if (moduleName === 'langchain/text_splitter') return { RecursiveCharacterTextSplitter: class {} };
+    if (moduleName === '@whiskeysockets/baileys') return {
+      makeWASocket: () => ({}),
+      useMultiFileAuthState: async () => ({ state: {}, saveCreds: async () => {} }),
+      DisconnectReason: {}
+    };
+    if (moduleName === 'openai') return class {};
+    if (moduleName === 'node-cron') return { schedule(){} };
+    if (moduleName === 'sqlite3') return { verbose: () => ({ Database: function(){} }) };
+    if (moduleName === './ciptPrompt.js') return { getCiptPrompt: async () => '' };
+    if (moduleName === './sheetsChamados') return {
+      registrarChamado: async () => {},
+      atualizarStatusChamado: async () => {},
+      verificarChamadosAbertos: async () => []
+    };
+    return originalRequire.apply(this, arguments);
+  };
+  delete require.cache[indexPath];
+  try {
+    require(indexPath);
+  } finally {
+    Module.prototype.require = originalRequire;
+    delete require.cache[indexPath];
+  }
+}
+
+(async () => {
+  if (fs.existsSync(LOCK_PATH)) fs.unlinkSync(LOCK_PATH);
+
+  loadIndex();
+  assert(fs.existsSync(LOCK_PATH), 'lockfile should exist after first load');
+  const cleanup = process.listeners('exit').find(fn => fn.toString().includes('LOCK_FILE'));
+
+  let exitCode;
+  let logged = '';
+  const origExit = process.exit;
+  const origErr = console.error;
+  process.exit = code => { exitCode = code; throw new Error('exit'); };
+  console.error = msg => { logged += String(msg); };
+
+  assert.throws(() => loadIndex(), /exit/);
+
+  console.error = origErr;
+  process.exit = origExit;
+
+  assert.strictEqual(exitCode, 1);
+  assert(logged.includes('cipt-bot.lock'));
+
+  cleanup();
+  process.removeListener('exit', cleanup);
+  assert(!fs.existsSync(LOCK_PATH), 'lockfile should be removed on cleanup');
+})();
+


### PR DESCRIPTION
## Summary
- ensure the bot creates a `cipt-bot.lock` lockfile and exits if another instance is running
- clean up the lockfile on shutdown
- add tests covering lockfile behavior and update existing tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1d9c727d08333a9e03a73d740aacc