### PR TITLE
Check connection status before updating flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -684,7 +684,10 @@ async function startBot() {
     const { connection, lastDisconnect, qr } = update;
     const err = update?.error;
     // considera aberto apenas se a conexão estiver marcada como 'open'
-    isConnected = connection === 'open';
+    if (typeof connection !== 'undefined') {
+      console.log('🔄 Estado da conexão:', connection);
+      isConnected = connection === 'open';
+    }
     if (reconnectTimer) {
       clearTimeout(reconnectTimer);
       reconnectTimer = null;


### PR DESCRIPTION
## Summary
- Guard against undefined connection before setting `isConnected`
- Log connection state for easier debugging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1de6bfc788333af2ef88b33d25709