### PR TITLE
Check WebSocket readyState before reconnect

### DIFF
--- a/index.js
+++ b/index.js
@@ -673,10 +673,13 @@ async function startBot() {
 
   if (wsCheckInterval) clearInterval(wsCheckInterval);
   wsCheckInterval = setInterval(() => {
-    if (!sock?.ws || sock.ws.readyState !== 1) {
-      console.warn(`[reconnect][stale] readyState=${sock?.ws?.readyState}`);
+    const readyState = sock?.ws?.readyState;
+    if (isConnected && typeof readyState === 'number' && readyState !== 1) {
+      console.warn(`[reconnect][stale] readyState=${readyState}`);
       isConnected = false;
       scheduleReconnect();
+    } else if (readyState === undefined) {
+      console.debug('[reconnect][stale] readyState=undefined');
     }
   }, 15000);
 


### PR DESCRIPTION
## Summary
- Handle stale WebSocket connections by verifying readyState before reconnecting
- Log debug when readyState is undefined to aid troubleshooting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1dfe607688333804b9cd62b94ac14